### PR TITLE
Context mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Shell-AI will then suggest 3 commands to fulfill your request:
 6. **`OPENAI_API_TYPE`**: Set to "azure" if you are using Azure deployments.
 7. **`AZURE_DEPLOYMENT_NAME`**: Your Azure deployment name (required if using Azure).
 8. **`AZURE_API_BASE`**: Your Azure API base (required if using Azure).
+9. **`CTX`**: Allow the assistant to keep the console outputs as context allowing the LLM to produce more precise outputs. ***IMPORTANT***: the outputs will be sent to OpenAI through their API, be careful if any sensitive data. Default to false.
 
 ### Configuration File
 
@@ -69,7 +70,8 @@ Example `config.json`:
 {
   "OPENAI_API_KEY": "your_openai_api_key_here",
   "OPENAI_MODEL": "gpt-3.5-turbo",
-  "SHAI_SUGGESTION_COUNT": "3"
+  "SHAI_SUGGESTION_COUNT": "3",
+  "CTX": true
 }
 ```
 

--- a/test/test_context_manager.py
+++ b/test/test_context_manager.py
@@ -1,0 +1,35 @@
+import unittest
+from shell_ai.code_parser import _ContextManager, ContextManager, MAX_CONTEXT_TOKENS
+
+class TestContextManager(unittest.TestCase):
+    def setUp(self):
+        self.ctx_manager = ContextManager
+
+    def test_add_token(self):
+        self.ctx_manager.add_token('token1')
+        self.assertEqual(len(self.ctx_manager.token_buffer), 1)
+        self.assertEqual(self.ctx_manager.token_buffer[0], 'token1')
+        self.ctx_manager.flush()
+
+    def test_add_chunk(self):
+        chunk = ['chunk', 'of', 'tokens']
+        self.ctx_manager.add_chunk(chunk)
+        buffer_list = list(self.ctx_manager.token_buffer)
+        self.assertEqual(len(buffer_list), len(chunk))
+        self.assertEqual(buffer_list[-len(chunk):], chunk)
+        self.ctx_manager.flush()
+
+    def test_get_ctx(self):
+        tokens = ['token' + str(i) for i in range(MAX_CONTEXT_TOKENS + 100)]
+        self.ctx_manager.add_chunk(tokens)
+        expected_ctx = ''.join(tokens[-MAX_CONTEXT_TOKENS:])
+        self.assertEqual(self.ctx_manager.get_ctx(), expected_ctx)
+        self.ctx_manager.flush()
+
+    def test_singleton_instance(self):
+        new_ctx_manager = _ContextManager()
+        self.assertIs(self.ctx_manager, new_ctx_manager)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adresses issue #8 

It allows to keep the last command (1500 tokens) as context for the next one.
When in context mode, it launches a session that keeps running until dismiss or keyboard interrupt.
As mentioned in the issue this is an option that is disabled by default. It is enabled by setting the ‘CTX’ flag to true in the config file.
By default, everything works as before.

It implements a singleton class to keep track of things (_ContextManager) and feeds the prompt with it plus other adjustments relative to keeping a session going.