### PR TITLE
Add specific Python requirements for Linux to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ You can install Shell-AI directly from PyPI using pip:
 pip install shell-ai
 ```
 
+Note that on Linux, Python 3.10 or later is required.
+
 After installation, you can invoke the utility using the `shai` command.
 
 ## Usage


### PR DESCRIPTION
shell-ai didn't work on my Ubuntu 20.04 box (still supported until 2025) because that distro has Python 3.8 and shell-ai's main.py uses platform.freedesktop_os_release() which was added in Python 3.10.

Hopefully this saves someone time if they don't meet the requirements.