### PR TITLE
Using "BUILD_ID" if "VERSION_ID" is missing.

### DIFF
--- a/shell_ai/main.py
+++ b/shell_ai/main.py
@@ -132,7 +132,7 @@ def main():
 
     if platform.system() == "Linux":
         info = platform.freedesktop_os_release()
-        plaform_string =  f"The system the shell command will be executed on is {platform.system()} {platform.release()}, running {info['ID']} version {info['VERSION_ID']}."
+        plaform_string =  f"The system the shell command will be executed on is {platform.system()} {platform.release()}, running {info['ID']} version {info.get('VERSION_ID', info['BUILD_ID'])}."
     else:
         plaform_string = f"The system the shell command will be executed on is {platform.system()} {platform.release()}."
 


### PR DESCRIPTION
On some Linux distros (e.g., Arch Linux) "VERSION_ID" does not seem to be available in the platform.freedesktop_os_release() dict.

```
> platform.freedesktop_os_release()
{'NAME': 'Arch Linux', 'ID': 'arch', 'PRETTY_NAME': 'Arch Linux', 'BUILD_ID': 'rolling', 'ANSI_COLOR': '38;2;23;147;209', 'HOME_URL': 'https://archlinux.org/', 'DOCUMENTATION_URL': 'https://wiki.archlinux.org/', 'SUPPORT_URL': 'https://bbs.archlinux.org/', 'BUG_REPORT_URL': 'https://gitlab.archlinux.org/groups/archlinux/-/issues', 'PRIVACY_POLICY_URL': 'https://terms.archlinux.org/docs/privacy-policy/', 'LOGO': 'archlinux-logo'}
```

The current code causes a KeyError:

```
Traceback (most recent call last):
  File "/home/user/.local/bin/shai", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/.local/share/pipx/venvs/shell-ai/lib/python3.12/site-packages/shell_ai/main.py", line 135, in main
    plaform_string =  f"The system the shell command will be executed on is {platform.system()} {platform.release()}, running {info['ID']} version {info['VERSION_ID']}."
                                                                                                                                                    ~~~~^^^^^^^^^^^^^^
KeyError: 'VERSION_ID'
```

"VERSION_ID" should return the OS version, so I think that using "BUILD_ID" could be a good substitute and seems to be available.