### PR TITLE
Write executed command to shell history for easy reuse.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r', encoding='utf-8') as f:
 
 setup(
     name='shell-ai',
-    version='0.3.24',
+    version='0.3.25',
     author='Rick Lamers',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Write the command executed by the user to the shell history. Supported supported shells are zsh, bash, csh, tcsh, ksh, and fish. Also add an environment variable SHAI_SKIP_HISTORY which disables this behavior.