### PR TITLE
fix ollama-env and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Shell-AI can be configured through environment variables or a config file locate
 ### Environment Variables
 
 - `OPENAI_API_KEY`: (Required) Your OpenAI API key, leave empty if you use ollama
-- `GROQ_API_KEY`: (Required if using Groq) Your Groq API key
 - `OPENAI_MODEL`: The OpenAI model to use (default: "gpt-3.5-turbo")
+- `OPENAI_API_BASE`: The OpenAI API / OpenAI compatible API endpoint to use (default: None)
+- `GROQ_API_KEY`: (Required if using Groq) Your Groq API key
 - `SHAI_SUGGESTION_COUNT`: Number of suggestions to generate (default: 3)
 - `SHAI_SKIP_CONFIRM`: Skip command confirmation when set to "true"
 - `SHAI_SKIP_HISTORY`: Skip writing to shell history when set to "true"
@@ -71,6 +72,19 @@ Shell-AI can be configured through environment variables or a config file locate
 }
 ```
 
+### Config Example for OpenAI compatible
+
+```json
+{
+   "SHAI_API_PROVIDER": "openai",
+   "OPENAI_API_KEY": "deepseek_api_key",
+   "OPENAI_API_BASE": "https://api.deepseek.com",
+   "OPENAI_MODEL": "deekseek-chat",
+   "SHAI_SUGGESTION_COUNT": "3",
+   "SHAI_SUGGESTION_COUNT": "3",
+   "CTX": true
+}
+```
 
 ### Config Example for Ollama
 ```json

--- a/shell_ai/main.py
+++ b/shell_ai/main.py
@@ -104,7 +104,7 @@ def main():
     OPENAI_MODEL = os.environ.get("OPENAI_MODEL", loaded_config.get("OPENAI_MODEL"))
     OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", loaded_config.get("OLLAMA_MODEL","phi3.5"))
     OPENAI_MAX_TOKENS = os.environ.get("OPENAI_MAX_TOKENS", None)
-    OLLAMA_MAX_TOKENS = os.environ.get("OLLAMA_MAX_TOKENS", loaded_config.get("OLLAMA_MAX_TOKENS",1500)))
+    OLLAMA_MAX_TOKENS = os.environ.get("OLLAMA_MAX_TOKENS", loaded_config.get("OLLAMA_MAX_TOKENS",1500))
     OLLAMA_API_BASE = os.environ.get("OLLAMA_API_BASE",  loaded_config.get("OLLAMA_API_BASE","http://localhost:11434/v1/"))
     OPENAI_API_BASE = os.environ.get("OPENAI_API_BASE", None)
     OPENAI_ORGANIZATION = os.environ.get("OPENAI_ORGANIZATION", None)


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixes a syntax error in the Ollama integration code and updates the README with OpenAI-compatible API configuration examples.

- Fixed a syntax error in `shell_ai/main.py` by removing an extra closing parenthesis in the `OLLAMA_MAX_TOKENS` variable assignment.
- Added documentation for the `OPENAI_API_BASE` environment variable in the README.md.
- Added a new configuration example section in README.md for using OpenAI-compatible APIs like DeepSeek.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

I didn't notice that the original project already had a variable to set the API KEY BASE URL, that was my mistake. Then I found a small mistake in your merged Ollama integration code, an extra parenthesis, I have deleted it and updated the README a little bit